### PR TITLE
Feature/disconnect timer

### DIFF
--- a/Desk Controller/Controller/DeskController.swift
+++ b/Desk Controller/Controller/DeskController.swift
@@ -9,33 +9,69 @@ import Foundation
 
 class DeskController: ObservableObject {
     
-    let bluetoohDelegate: CBManagerDelegate
+    let btDelegate: CBManagerDelegate
     var settings: Settings
+    var disconnectTimer: Timer?
     
     init(for btDelegate: CBManagerDelegate, settings: Settings) {
-        self.bluetoohDelegate = btDelegate
+        self.btDelegate = btDelegate
         self.settings = settings
     }
     
+    private func cancelConnectionAfterTimeout() {
+        // invalidate timer then start a new one
+        if let timer = self.disconnectTimer {
+            timer.invalidate()
+        }
+        disconnectTimer = Timer.scheduledTimer(withTimeInterval: 20.0, repeats: false, block: { timer in
+            if let peripheral = self.btDelegate.peripheral {
+                self.btDelegate.cbManager.cancelPeripheralConnection(peripheral)
+                print("Cancel connection to desk!")
+            }
+        })
+    }
+    
+    func checkForDeskConnection() {
+        if btDelegate.peripheral == nil {
+            self.btDelegate.initiateConnectToDesk()
+        }
+    }
+    
     func moveTable(_ direction: MovementDirection) {
-        self.bluetoohDelegate.desk?.currentDeskState = .unknown
-        self.bluetoohDelegate.moveTable(direction: direction)
+        if btDelegate.peripheral == nil {
+            self.btDelegate.initiateConnectToDesk { result in
+                switch result {
+                case .success(let _):
+                    self.btDelegate.desk?.currentDeskState = .unknown
+                    self.btDelegate.moveTable(direction: direction)
+                    self.cancelConnectionAfterTimeout()
+                case .failure(let _):
+                    return
+                }
+            }
+        } else {
+            self.btDelegate.desk?.currentDeskState = .unknown
+            self.btDelegate.moveTable(direction: direction)
+            self.cancelConnectionAfterTimeout()
+        }
     }
     
     func moveTable(to state: DeskState) {
+        self.checkForDeskConnection()
         switch state {
         case .low:
             let tableTargetHeight: Float = settings.deskSettingLow
-            self.bluetoohDelegate.moveTable(to: tableTargetHeight, with: .low)
+            self.btDelegate.moveTable(to: tableTargetHeight, with: .low)
         case .mid:
             let tableTargetHeight: Float = settings.deskSettingMid
-            self.bluetoohDelegate.moveTable(to: tableTargetHeight, with: .mid)
+            self.btDelegate.moveTable(to: tableTargetHeight, with: .mid)
         case .high:
             let tableTargetHeight: Float = settings.deskSettingHigh
-            self.bluetoohDelegate.moveTable(to: tableTargetHeight, with: .high)
+            self.btDelegate.moveTable(to: tableTargetHeight, with: .high)
         case .unknown:
             return
         }
+        self.cancelConnectionAfterTimeout()
     }
     
 }


### PR DESCRIPTION
This will add a disconnect timer, that is triggered after 20 seconds every time a table movement occurred. This is needed, because sometimes the active connection disables manual table movements. When the desk is not connected and a movement is triggered, the connection is re-established with a completion handler triggered when both the desk is connected and the desk characteristics are received.